### PR TITLE
Domain error when creating an intercompany invoice

### DIFF
--- a/invoice.py
+++ b/invoice.py
@@ -305,7 +305,7 @@ class InvoiceLine(metaclass=PoolMeta):
             line.invoice_type = self.invoice.intercompany_type
             line.company = target_company
             if self.party:
-                line.party = target_company.party
+                line.party = self.company.party
             line.account = self.get_intercompany_account()
             line.taxes = self.get_intercompany_taxes()
             line.origin = self


### PR DESCRIPTION
In tryton6.0, when creating intercompany invoices it raises a domain error regarding the new invoice lines,
because line.party is not equal to its invoice.party.

This [issue](https://bugs.tryton.org/issue9854) from module account_invoice changed the domain,
before it only restricted the invoice.company and invoice.line.company were equal,
but now also checks if both parties are the same.